### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # kagi-server MCP Server
 
+[![smithery badge](https://smithery.ai/badge/kagi-server)](https://smithery.ai/protocol/kagi-server)
 MCP server for Kagi API integration
 
 This is a TypeScript-based MCP server that integrates the Kagi Search API. It demonstrates core MCP concepts by providing:
@@ -46,6 +47,14 @@ KAGI_API_KEY=your_api_key_here
 Make sure to add `.env` to your `.gitignore` file to keep your API key secure.
 
 ## Installation
+
+### Installing via Smithery
+
+To install Kagi Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/kagi-server):
+
+```bash
+npx @smithery/cli install kagi-server --client claude
+```
 
 To use with Claude Desktop, add the server config:
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install Kagi Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.