### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is a TypeScript-based MCP server that integrates the Kagi Search API. It de
 
 - Tools for performing web searches and other operations using Kagi's API (currently in private beta)
 
+<a href="https://glama.ai/mcp/servers/z0f3dzmha4"><img width="380" height="200" src="https://glama.ai/mcp/servers/z0f3dzmha4/badge" alt="Kagi server MCP server" /></a>
+
 ## Features
 
 ### Implemented Tools


### PR DESCRIPTION
This PR adds a badge for the Kagi MCP server server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/z0f3dzmha4

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.